### PR TITLE
Added explicit version to fix maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>


### PR DESCRIPTION
Added explicit version `2.2.1` for build plugin `org.apache.maven.plugins`/`maven-source-plugin`
